### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The DevOps working group is an umbrella for multiple, more specific projects. Se
 
 - Communication:
     - The Open edX forum [DevOps working group category](https://discuss.openedx.org/c/working-groups/devops), which is the primary communication channel for this working group. Members are encouraged to subscribe to the notifications for this category ("Watch first post").
-    - We also use Slack for quick one-off Q&A: see the [#wg-devops](https://app.slack.com/client/T02SNA1T6/C04J9GTLHH8) channel (if you're not already on the Open edX Slack read [this](https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst#slack)). Slack is great for talking to individual people, but most in-depth conversations should happen on the forum or on repository tickets.
+    - We also use Slack for quick one-off Q&A: see the [#wg-devops](https://app.slack.com/client/T02SNA1T6/C04J9GTLHH8) channel (if you're not already on the Open edX Slack [get an invitation here](https://openedx.org/slack)). Slack is great for talking to individual people, but most in-depth conversations should happen on the forum or on repository tickets.
 - Issue management: we use this [project board](https://github.com/orgs/openedx/projects/42)
 - General information and Confluence workspaces:
     - [DevOps working group workspace](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3620044867/DevOps+Working+Group) (we try to use it as little as possible and keep most of the information in the forum or in this GitHub project)
@@ -79,6 +79,6 @@ Awesome! Have a look at the following issues:
 - Developer Experience ["good first issues"](https://github.com/openedx/wg-developer-experience/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue)
 - Large Instances ["good first issues"](https://github.com/orgs/openedx/projects/42/views/3)
 - Tutor ["good first issues"](https://github.com/orgs/overhangio/projects/4/views/1?filterQuery=-label%3A%22good+first+issue%22) (check the "Backlog" column)
-Also, read the Open edX [CONTRIBUTING.rst](https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst) document.
+Also, read the Open edX [Contributing Guidelines](https://github.com/openedx/.github/blob/master/CONTRIBUTING.md) document.
 
 We're happy to have you on board :)


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
